### PR TITLE
Use new location of Python 3.10 conda env

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,7 @@
 # SLAC RELEASE_NOTES for PVA Gateway
+pre-release     2025-04-29 Jeremy Lorelli
+    Updated path of the rhel7 py3.10 env in lcls_setup_py310.sh
+
 R4.1.7-1.0.2    2024-01-22 Jeremy Lorelli
     Remove old setup scripts, use Python 3.10 env only
     Remove RELEASE_SITE, do not track in GIT

--- a/lcls_setup_py310.sh
+++ b/lcls_setup_py310.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
 # Setup using the new Python 3.10 conda env
-source $PACKAGE_SITE_TOP/anaconda/envs/python3.10envs/v1.0/bin/activate
-
+source $PACKAGE_SITE_TOP/anaconda/envs/python3.10envs/rhel7/v1.0/bin/activate


### PR DESCRIPTION
Maintenance commit. The path of the rhel7 conda env changed.

Not going to release a new version of p4p just yet.