### PR TITLE
Add local p4p dir to the head of the PYTHONPATH instead of the tail

### DIFF
--- a/src/bootgw.py
+++ b/src/bootgw.py
@@ -25,7 +25,7 @@ import os
 
 mypath = os.path.dirname(os.path.abspath(__file__))
 
-sys.path.append(os.path.join(mypath, '{pythonpath}'))
+sys.path.insert(0, os.path.join(mypath, '{pythonpath}'))
 
 from p4p.gw import main
 main()


### PR DESCRIPTION
This allows the local p4p installation to override what's installed in the conda env (if p4p is installed there)
